### PR TITLE
More Robust Support for Decimal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,3 +43,34 @@ Notes:
 
 #.  Alignment and padding are required.
 
+#.  If 'decimal' type is used, there are two other optional parameters,
+    'precision' and 'separator'. 
+        
+        a. 'precision' is a integer that specifies how many places the decimal needs 
+        to be rounded to. 
+        
+        b. 'separator' can be a string or None. If None, the resultant value will
+        not have a separator, the value will be offset by the number of precision
+        decimals for example::
+            
+            CONFIG = {
+                "money": {
+                    "type": "decimal",
+                    "start_pos": 1,
+                    "padding": "0",
+                    "end_pos": 10,
+                    "alignment": "right",
+                    "required": True,
+                    "precision": 4,
+                    "separator": None,
+                }
+            }
+            
+            fw = FixedWidth(CONFIG,**{'money':Decimal('1.0245678')})
+            
+            print fw.line
+            '0000010245\r\n'
+
+            
+            
+        

--- a/fixedwidth/fixedwidth.py
+++ b/fixedwidth/fixedwidth.py
@@ -4,7 +4,7 @@
 The FixedWidth class definition.
 """
 
-from decimal import Decimal
+from decimal import *
 
 class FixedWidth(object):
     """
@@ -183,7 +183,38 @@ class FixedWidth(object):
         for field_name in [x[1] for x in self.ordered_fields]:
 
             if field_name in self.data:
+
                 datum = str(self.data[field_name])
+
+                if self.config[field_name]['type'] == 'decimal':
+
+                    if 'precision' in self.config[field_name]:
+
+                        precision = self.config[field_name]['precision']
+                        sep = self.config[field_name].get('separator','.')
+
+                        decimal_context = Context(
+                            prec=256, rounding=ROUND_HALF_DOWN,
+                        )
+                        setcontext(decimal_context)
+
+                        if sep is None:
+
+                            multiplier = pow(10.0,precision)
+
+                            datum = str(
+                                self.data[field_name] * Decimal(multiplier)
+                            ).split('.')[0]
+
+                        else:
+
+                            chunks = str(self.data[field_name]).split('.')
+                            datum = '{}{}{}'.format(
+                                chunks[0],
+                                sep,
+                                chunks[1][:precision]
+                            )
+
             else:
                 datum = ''
 

--- a/fixedwidth/fixedwidth.py
+++ b/fixedwidth/fixedwidth.py
@@ -155,10 +155,18 @@ class FixedWidth(object):
                     but the value is not of that type." \
                     % (field_name, parameters['type']))
 
-                #ensure value passed in is not too long for the field
-                if len(str(self.data[field_name])) > parameters['length']:
+                if (
+                    parameters['type'] == 'decimal' and
+                    'precision' in parameters):
+
+                    datum = self._build_decimal_chunk(field_name)
+                else:
+                    datum = str(self.data[field_name])
+
+                 #ensure value passed in is not too long for the field
+                if len(datum) > parameters['length']:
                     raise ValueError("%s is too long (limited to %d \
-                        characters)." % (field_name, parameters['length']))
+                    characters)." % (field_name, parameters['length']))
 
                 if 'value' in parameters \
                     and parameters['value'] != self.data[field_name]:
@@ -183,6 +191,36 @@ class FixedWidth(object):
 
         return True
 
+    def _build_decimal_chunk(self,field_name):
+
+        precision = self.config[field_name]['precision']
+        sep = self.config[field_name].get('separator','.')
+
+        decimal_context = Context(
+            prec=256, rounding=ROUND_HALF_DOWN,
+        )
+        setcontext(decimal_context)
+
+        if sep is None:
+
+            multiplier = pow(10.0,precision)
+
+            datum = str(
+                self.data[field_name] * Decimal(multiplier)
+            ).split('.')[0]
+
+        else:
+
+            chunks = str(self.data[field_name]).split('.')
+            datum = '{}{}{}'.format(
+                chunks[0],
+                sep,
+                chunks[1][:precision]
+            )
+        
+        return datum
+
+
     def _build_line(self):
 
         """
@@ -200,34 +238,9 @@ class FixedWidth(object):
 
                 datum = str(self.data[field_name])
 
-                if self.config[field_name]['type'] == 'decimal':
-
-                    if 'precision' in self.config[field_name]:
-
-                        precision = self.config[field_name]['precision']
-                        sep = self.config[field_name].get('separator','.')
-
-                        decimal_context = Context(
-                            prec=256, rounding=ROUND_HALF_DOWN,
-                        )
-                        setcontext(decimal_context)
-
-                        if sep is None:
-
-                            multiplier = pow(10.0,precision)
-
-                            datum = str(
-                                self.data[field_name] * Decimal(multiplier)
-                            ).split('.')[0]
-
-                        else:
-
-                            chunks = str(self.data[field_name]).split('.')
-                            datum = '{}{}{}'.format(
-                                chunks[0],
-                                sep,
-                                chunks[1][:precision]
-                            )
+                if (self.config[field_name]['type'] == 'decimal' and
+                    'precision' in self.config[field_name]):
+                    datum = self._build_decimal_chunk(field_name)
 
             else:
                 datum = ''

--- a/fixedwidth/fixedwidth.py
+++ b/fixedwidth/fixedwidth.py
@@ -99,6 +99,20 @@ class FixedWidth(object):
                     raise ValueError("Default value for %s is not a valid %s" \
                         % (key, value['type']))
 
+            # If value is a decimal type, check that optional decimal args are
+            # valid.
+            if value['type'] == 'decimal':
+                if 'precision' in value:
+                    if (
+                        not isinstance(value['precision'],int) or
+                        value['precision'] < 0
+                    ):
+                        raise ValueError("Precision must be positive integer")
+
+                if 'separator' in value:
+                    if value['separator'] not in [None,',','.']:
+                        raise ValueError("Separator must be: ',','.', or None")
+
         #ensure start_pos and end_pos or length is correct in config
         current_pos = 1
         for start_pos, field_name in self.ordered_fields:

--- a/fixedwidth/tests/fixedwidth_test.py
+++ b/fixedwidth/tests/fixedwidth_test.py
@@ -57,7 +57,7 @@ SAMPLE_CONFIG = {
         "length": 20,
         "alignment": "left",
         "required": False
-    },
+    }
 }
 
 class TestFixedWidth(unittest.TestCase):

--- a/fixedwidth/tests/fixedwidth_test.py
+++ b/fixedwidth/tests/fixedwidth_test.py
@@ -6,6 +6,7 @@ Tests for the FixedWidth class.
 
 import unittest
 from copy import deepcopy
+from decimal import Decimal
 
 from ..fixedwidth import FixedWidth
 
@@ -56,10 +57,8 @@ SAMPLE_CONFIG = {
         "length": 20,
         "alignment": "left",
         "required": False
-    }
-
+    },
 }
-
 
 class TestFixedWidth(unittest.TestCase):
     """
@@ -83,6 +82,53 @@ class TestFixedWidth(unittest.TestCase):
         good = (
             "Michael   Smith                              "
             "032vegetarian          \r\n"
+        )
+
+        self.assertEquals(fw_string, good)
+
+    def test_decimal(self):
+        """
+        Test a simple, valid example.
+        """
+
+        fw_config = deepcopy(SAMPLE_CONFIG)
+
+        fw_config["cost"] = {
+            "type": "decimal",
+            "start_pos": 69,
+            "default": Decimal("1.02093982"),
+            "padding": "0",
+            "end_pos": 78,
+            "length": 10,
+            "alignment": "right",
+            "required": False,
+            "precision": 4
+        }
+
+        fw_config["cost_mainframe"] = {
+            "type": "decimal",
+            "start_pos": 79,
+            "default": Decimal("1.02093982"),
+            "padding": "0",
+            "end_pos": 88,
+            "length": 10,
+            "alignment": "right",
+            "required": False,
+            "precision": 4,
+            "separator": None
+        }
+
+        fw_obj = FixedWidth(fw_config)
+        fw_obj.update(
+            last_name="Smith", first_name="Michael",
+            age=32, meal="vegetarian"
+        )
+
+        fw_string = fw_obj.line
+
+        good = (
+            "Michael   Smith                              "
+            "032vegetarian          00001.02090000010209\r\n"
         )
 
         self.assertEquals(fw_string, good)
@@ -125,3 +171,6 @@ class TestFixedWidth(unittest.TestCase):
         self.assertEquals(values["last_name"], "Smith")
         self.assertEquals(values["age"], 32)
         self.assertEquals(values["meal"], "vegetarian")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Have had several use cases where an old mainframe computer is looking for a fixed-width file where some of the numeric values where not allowed to have '.' separators. i.e in a 0-padded 20 length field the number 345322.6565 needs to be written as `00000000003453226565`.

I added some optional config parameters for decimal to accommodate this.

I added some CONFIG verification in the `python def __init__()` function and added some light documentation in the README.

I added one test. (all 4 are passing)

Let me know if you need me to tweak anything.
