### PR TITLE
Allow tests to be run easily while developping 

### DIFF
--- a/fixedwidth/tests/fixedwidth_test.py
+++ b/fixedwidth/tests/fixedwidth_test.py
@@ -9,7 +9,10 @@ from copy import deepcopy
 
 import datetime
 
-from fixedwidth import FixedWidth
+try:
+    from fixedwidth import FixedWidth
+except ImportError:
+    from fixedwidth.fixedwidth import FixedWidth
 
 SAMPLE_CONFIG = {
 

--- a/fixedwidth/tests/fixedwidth_test.py
+++ b/fixedwidth/tests/fixedwidth_test.py
@@ -127,7 +127,7 @@ SAMPLE_CONFIG = {
         "type": "date",
         "default": None,
         "start_pos": 114,
-        "end_pos": 120,
+        "end_pos": 121,
         "alignment": "right",
         "padding": " ",
         "format": '%Y%m%d',
@@ -157,7 +157,7 @@ class TestFixedWidth(unittest.TestCase):
 
         good = (
             "Michael   Smith                              "
-            "032vegetarian             40.7128   -74.0059-100   98.6201701011.001       \r\n"
+            "032vegetarian             40.7128   -74.0059-100   98.6201701011.001        \r\n"
         )
 
         self.assertEqual(fw_string, good)
@@ -193,7 +193,7 @@ class TestFixedWidth(unittest.TestCase):
         fw_obj = FixedWidth(fw_config)
         fw_obj.line = (
             "Michael   Smith                              "
-            "032vegetarian             40.7128   -74.0059-100   98.6201701011.000       \r\n"
+            "032vegetarian             40.7128   -74.0059-100   98.6201701011.000        \r\n"
         )
 
         values = fw_obj.data
@@ -236,7 +236,7 @@ class TestFixedWidth(unittest.TestCase):
 
         good = (
             "Michael   Smith                              "
-            "032vegetarian             40.7128   -74.0059-100   98.6201701011.000       \r\n"
+            "032vegetarian             40.7128   -74.0059-100   98.6201701011.000        \r\n"
         )
 
         self.assertEqual(fw_obj.line, good)
@@ -251,7 +251,7 @@ class TestFixedWidth(unittest.TestCase):
         fw_obj = FixedWidth(fw_config)
         fw_obj.line = (
             "Michael   Smith                              "
-            "032vegetarian             40.7128   -74.0059-100   98.620170101             \r\n"
+            "032vegetarian             40.7128   -74.0059-100   98.620170101              \r\n"
         )
 
 


### PR DESCRIPTION
This is a direct continuation of #3. I spend a fair amount of time trying to guess how to make the base `from fixedwidth import` to work, before I noticed that issue, and I then conclude that when the package is not fully installed, one has to use the `fixedwidth.fixedwdith` notation. So I designed the proposed patch, and it allowed me to boost productivity!
Doing tests allowed me to fix an inconsistency inside the test suite.